### PR TITLE
Correct issue #28 ("mainBetId":"None")

### DIFF
--- a/baseball_japan/WinamaxCrawler.py
+++ b/baseball_japan/WinamaxCrawler.py
@@ -90,15 +90,20 @@ class WinamaxCrawler:
                         raise ParseException
 
                     try:
-                        mainBet = PRELOADED_STATE["bets"][str(match["mainBetId"])]
 
-                        odd1 = Odd(datetime.now(), oddStatus, OddType.RESULT, match["competitor1Id"], PRELOADED_STATE["odds"][str(mainBet["outcomes"][0])])
-                        odd2 = Odd(datetime.now(), oddStatus, OddType.RESULT, match["competitor2Id"], PRELOADED_STATE["odds"][str(mainBet["outcomes"][1])])
-                        
-                        retrieved_match.odds.append(odd1)
-                        retrieved_match.odds.append(odd2)
+                        # at the end of live matches, main bet is not proposed anymore
+                        # testing if we are proposed a main bet to prevent KeyError
+                        if match["mainBetId"] != "None":
 
-                        retrieved_matches.append(retrieved_match)
+                            mainBet = PRELOADED_STATE["bets"][str(match["mainBetId"])]
+
+                            odd1 = Odd(datetime.now(), oddStatus, OddType.RESULT, match["competitor1Id"], PRELOADED_STATE["odds"][str(mainBet["outcomes"][0])])
+                            odd2 = Odd(datetime.now(), oddStatus, OddType.RESULT, match["competitor2Id"], PRELOADED_STATE["odds"][str(mainBet["outcomes"][1])])
+                            
+                            retrieved_match.odds.append(odd1)
+                            retrieved_match.odds.append(odd2)
+
+                            retrieved_matches.append(retrieved_match)
 
                     except KeyError as ke:
                         logging.error("OS error: {0}".format(ke))


### PR DESCRIPTION
Sometimes we are not proposed a main bet anymore (at the end of live matches): "mainBetId":"None"
adding a condition to protect this case. Not sure now, this condition is the right one (maybe 'None' text comparison is not the right one). Let's see with the next runs)